### PR TITLE
Feat: Lägg till grundläggande mappstruktur för API

### DIFF
--- a/API/Controllers/.gitkeep
+++ b/API/Controllers/.gitkeep
@@ -1,0 +1,6 @@
+﻿namespace API.Controllers
+{
+    public class _
+    {
+    }
+}

--- a/API/DTOs/.gitkeep
+++ b/API/DTOs/.gitkeep
@@ -1,0 +1,6 @@
+﻿namespace API.DTOs
+{
+    public class _
+    {
+    }
+}

--- a/API/Models/.gitkeep
+++ b/API/Models/.gitkeep
@@ -1,0 +1,6 @@
+﻿namespace API.Models
+{
+    public class _
+    {
+    }
+}

--- a/API/Repositories/.gitkeep
+++ b/API/Repositories/.gitkeep
@@ -1,0 +1,6 @@
+﻿namespace API.Repositories
+{
+    public class _
+    {
+    }
+}

--- a/API/Services/.gitkeep
+++ b/API/Services/.gitkeep
@@ -1,0 +1,6 @@
+﻿namespace API.Services
+{
+    public class _
+    {
+    }
+}


### PR DESCRIPTION
### Vad?
Denna pull request introducerar den grundläggande och rekommenderade mappstrukturen för API:et.

### Varför?
För att från start etablera en ren, skalbar och testbar arkitektur. Detta separerar ansvarsområden enligt standard-praxis med mappar för:
- Controllers
- Services
- Repositories
- Models
- DTOs

### Övrigt
- Lade till `.gitkeep`-filer i de tomma mapparna för att säkerställa att de spåras korrekt av Git.